### PR TITLE
fix(extractor): scope ffprobe path replacement to filename only

### DIFF
--- a/src/llama_video/extractor.py
+++ b/src/llama_video/extractor.py
@@ -83,7 +83,9 @@ class Extractor:
     async def _get_video_info(self, video_path: Path) -> tuple[int, int, float]:
         """Get video dimensions and duration using ffprobe."""
         cmd = [
-            self.ffmpeg_path.replace("ffmpeg", "ffprobe"),
+            str(Path(self.ffmpeg_path).with_name(
+                Path(self.ffmpeg_path).name.replace("ffmpeg", "ffprobe")
+            )),
             "-v",
             "error",
             "-select_streams",


### PR DESCRIPTION
## Summary
- Fixes #2 — global `str.replace("ffmpeg", "ffprobe")` on the full path corrupts directory components containing "ffmpeg" (e.g. NixOS store paths)
- Uses `Path.name` to isolate the replacement to just the binary filename, then reconstructs via `Path.with_name()`

## Test plan
- [x] All 12 existing extractor unit tests pass
- [x] Verified fix handles standard paths (`/usr/bin/ffmpeg` → `/usr/bin/ffprobe`) and NixOS paths (`/nix/store/...-ffmpeg-8.0.1-bin/bin/ffmpeg` → `/nix/store/...-ffmpeg-8.0.1-bin/bin/ffprobe`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)